### PR TITLE
Add Docker Compose deployment with PostgreSQL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+node_modules
+coverage
+logs
+*.log
+.env
+.env.*
+!.env.example
+.vscode
+Dockerfile
+docker-compose.yml
+.dockerignore
+bot/tests
+img
+dist

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy to .env and fill in before running `docker compose up`
+
+# --- Discord bot ---
+# Bot token from the Discord developer portal
+TOKEN=
+# Command prefix the bot listens for (e.g. `.c`, `.o`)
+PREFIX=.
+
+# --- PostgreSQL ---
+POSTGRES_USER=polycalculator
+POSTGRES_PASSWORD=
+POSTGRES_DB=polycalculator
+
+# --- Stats API / web server ---
+# Host port the API is published on
+API_PORT=3333
+
+# --- Slash-command registration (only needed for deploy-commands.js) ---
+# CLIENTID=
+# GUILDID=
+# PRODCLIENTID=
+# PRODTOKEN=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18.16-alpine
+
+WORKDIR /app
+
+# Install dependencies first so code changes don't bust the npm cache layer
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --chown=node:node . .
+
+USER node
+
+# Default to the Discord bot; docker-compose overrides this per service
+CMD ["node", "bot/index.js"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,38 @@
 ### Now having been granted the Verified tag on Discord, the bot boasts over 310k uses and has used optimization to calculate the best outcome for a fight!
 
 ### To find the Discord server of the bot, follow this [link](https://discord.gg/rtSTmd8)
+
+## Deployment (Docker Compose)
+
+The repo ships with a `docker-compose.yml` that runs the full stack on any host with Docker:
+
+-   **postgres** — PostgreSQL 16 with a persistent volume; `db/init.sql` creates the schema on first start
+-   **bot** — the Discord bot (`node bot/index.js`)
+-   **api** — the stats API + web frontend (`node server/index.js`), published on `API_PORT` (default 3333)
+
+### First-time setup
+
+```sh
+cp .env.example .env   # then fill in TOKEN and POSTGRES_PASSWORD
+docker compose up -d --build
+```
+
+The bot and API read `DATABASE_URL` (assembled by compose to point at the `postgres` service), so no further wiring is needed. Logs: `docker compose logs -f bot api`.
+
+To (re)register slash commands, run the one-off script inside the image:
+
+```sh
+docker compose run --rm -e CLIENTID=... -e GUILDID=... bot node deploy-commands.js
+```
+
+### Migrating data from an existing deployment
+
+On the old host, dump the current database, then restore it into the new stack **before** relying on `db/init.sql` data (the placeholder `units` table in particular should come from your real data):
+
+```sh
+pg_dump "$OLD_DATABASE_URL" --format=custom --file=polycalculator.dump
+docker compose up -d postgres
+docker compose cp polycalculator.dump postgres:/tmp/
+docker compose exec postgres pg_restore -U polycalculator -d polycalculator --clean --if-exists /tmp/polycalculator.dump
+docker compose up -d --build
+```

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,52 @@
+-- Schema for a fresh PolyCalculator database.
+-- Runs automatically the first time the postgres container starts with an
+-- empty data volume (via /docker-entrypoint-initdb.d).
+--
+-- If you are migrating from an existing deployment, skip this file and
+-- restore a dump instead — see the Deployment section of the README.
+
+-- Discord servers the bot has been invited to (bot/util/dbServers.js)
+CREATE TABLE IF NOT EXISTS servers (
+    server_id TEXT PRIMARY KEY,
+    server_name TEXT,
+    active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- Every command trigger, written by the bot and the web API
+-- (bot/util/util.js, server/api/command.js)
+CREATE TABLE IF NOT EXISTS stats (
+    id SERIAL PRIMARY KEY,
+    content TEXT,
+    author_id TEXT,
+    author_tag TEXT,
+    command TEXT,
+    attacker TEXT,
+    defender TEXT,
+    url TEXT,
+    message_id TEXT,
+    server_id TEXT,
+    will_delete BOOLEAN,
+    attacker_description TEXT,
+    defender_description TEXT,
+    reply_fields TEXT,
+    arg TEXT,
+    is_slash BOOLEAN,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS stats_command_idx ON stats (command);
+CREATE INDEX IF NOT EXISTS stats_server_id_idx ON stats (server_id);
+
+-- Unit reference data, read by the web API's `units` command
+-- (server/api/command.js: SELECT * FROM units). When migrating an existing
+-- deployment, the restored dump provides the real rows (and columns, if
+-- they differ) — this empty table is only a placeholder for fresh installs.
+CREATE TABLE IF NOT EXISTS units (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    max_hp INTEGER,
+    attack NUMERIC,
+    defence NUMERIC,
+    range INTEGER,
+    is_naval_unit BOOLEAN NOT NULL DEFAULT FALSE
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+    postgres:
+        image: postgres:16-alpine
+        restart: unless-stopped
+        environment:
+            POSTGRES_USER: ${POSTGRES_USER:-polycalculator}
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+            POSTGRES_DB: ${POSTGRES_DB:-polycalculator}
+        volumes:
+            - postgres-data:/var/lib/postgresql/data
+            # Runs only on first start, when the data volume is empty
+            - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+        healthcheck:
+            test:
+                [
+                    'CMD-SHELL',
+                    'pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}',
+                ]
+            interval: 5s
+            timeout: 5s
+            retries: 10
+
+    bot:
+        build: .
+        command: ['node', 'bot/index.js']
+        restart: unless-stopped
+        depends_on:
+            postgres:
+                condition: service_healthy
+        environment:
+            TOKEN: ${TOKEN:?set TOKEN (Discord bot token) in .env}
+            PREFIX: ${PREFIX:-.}
+            DATABASE_URL: postgres://${POSTGRES_USER:-polycalculator}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-polycalculator}
+
+    api:
+        build: .
+        command: ['node', 'server/index.js']
+        restart: unless-stopped
+        depends_on:
+            postgres:
+                condition: service_healthy
+        environment:
+            NODE_ENV: production
+            PORT: 3333
+            DATABASE_URL: postgres://${POSTGRES_USER:-polycalculator}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-polycalculator}
+        ports:
+            - '${API_PORT:-3333}:3333'
+
+volumes:
+    postgres-data:


### PR DESCRIPTION
- Dockerfile (node:18.16-alpine, matching .nvmrc) shared by the bot and API services
- docker-compose.yml running postgres 16, the Discord bot, and the stats API/frontend
- db/init.sql bootstrapping the servers, stats, and units tables on first start
- .env.example documenting required configuration (TOKEN, POSTGRES_PASSWORD, ...)
- README deployment section, including data migration via pg_dump/pg_restore

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W2W97uh3JBndtaBCfJ5h2x