### PR TITLE
Allow Cloaks to attack as city infiltration with a warning

### DIFF
--- a/bot/tests/bulk.test.js
+++ b/bot/tests/bulk.test.js
@@ -36,3 +36,11 @@ test('/b attackers: wa defender: de', () => {
         },
     })
 })
+
+test('/b attackers: cl defender: wa — cloak infiltration warning', () => {
+    const reply = replyData()
+    execute({}, 'cl, wa', reply, {})
+    expect(reply.content.length).toBe(1)
+    expect(reply.content[0][0]).toContain('infiltrating a city')
+    expect(reply.outcome.response).toBe(2)
+})

--- a/bot/tests/calcRegressions.test.js
+++ b/bot/tests/calcRegressions.test.js
@@ -85,3 +85,22 @@ test('ce 6, se, ki 3, wa v — halved+floored explosion, Warrior survives', asyn
     expect(reply.outcome.attackers[2].hpdefender).toBe(3)
     expect(reply.outcome.defender.afterhp).toBe(3)
 })
+
+test('cl, wa — cloak attacks with 2 att and warns about infiltration', async () => {
+    const reply = replyData()
+    await execute({}, 'cl, wa', reply, {})
+    expect(reply.content.length).toBe(1)
+    expect(reply.content[0][0]).toContain('infiltrating a city')
+    expect(reply.outcome.attackers[0].name).toBe('Cloak')
+    expect(reply.outcome.attackers[0].hpdefender).toBe(5)
+    expect(reply.outcome.attackers[0].afterhp).toBe(0)
+    expect(reply.outcome.defender.afterhp).toBe(5)
+})
+
+test('wa, cl — no infiltration warning when a Cloak defends', async () => {
+    const reply = replyData()
+    await execute({}, 'wa, cl', reply, {})
+    expect(reply.content).toEqual([])
+    expect(reply.outcome.attackers[0].afterhp).toBe(10)
+    expect(reply.outcome.defender.afterhp).toBe(-2)
+})

--- a/bot/tests/optim.test.js
+++ b/bot/tests/optim.test.js
@@ -266,3 +266,11 @@ test('/o attackers: se, ce 6, ki 3 defender: wa v — halved+floored explosion, 
     expect(reply.outcome.attackers[1].afterhp).toBe(2)
     expect(reply.outcome.attackers[1].hpdefender).toBe(3)
 })
+
+test('/o attackers: cl, wa defender: de — cloak infiltration warning', async () => {
+    const reply = replyData()
+    await execute({}, 'cl, wa, de', reply, {})
+    expect(reply.content.length).toBe(1)
+    expect(reply.content[0][0]).toContain('infiltrating a city')
+    expect(reply.outcome.attackers.map((a) => a.name)).toContain('Cloak')
+})

--- a/bot/unit/unit.js
+++ b/bot/unit/unit.js
@@ -27,6 +27,7 @@ module.exports = function buildMakeUnit() {
         final = false,
         canBoard = true,
         canAttack = true,
+        infiltrateOnly = false,
     } = {}) {
         if (currenthp <= 0)
             throw new Error('One of the units is already dead. RIP.')
@@ -238,6 +239,7 @@ module.exports = function buildMakeUnit() {
             },
             canBoard: canBoard,
             canAttack: canAttack,
+            infiltrateOnly: infiltrateOnly,
             makeNaval: function (navalUnitCode) {
                 if (this.bonus === 4)
                     throw 'Are you saying a naval unit can be in a city :thinking:...'

--- a/bot/util/fightEngine.js
+++ b/bot/util/fightEngine.js
@@ -9,6 +9,17 @@ const {
     evaluateWithTarget,
 } = require('./sequencer')
 
+function warnInfiltrateOnly(attackers, replyData) {
+    if (attackers.some((attacker) => attacker.infiltrateOnly)) {
+        replyData.content.push([
+            `The only way a ${
+                attackers.find((attacker) => attacker.infiltrateOnly).name
+            } attacks is by infiltrating a city, so this result only applies to a city infiltration.`,
+            {},
+        ])
+    }
+}
+
 function getDefenderBonusLabel(defender) {
     const labels = defender.poisoned
         ? { 0.5: '', 0.7: ' (protected)', 2: ' (walled)' }
@@ -18,6 +29,8 @@ function getDefenderBonusLabel(defender) {
 }
 
 module.exports.optim = function (attackers, defender, replyData, target) {
+    warnInfiltrateOnly(attackers, replyData)
+
     // Validate: units with no attack stat can only be used with explode modifiers
     for (const attacker of attackers) {
         if (attacker.canAttack === false && !attacker.exploding) {
@@ -251,6 +264,8 @@ module.exports.optim = function (attackers, defender, replyData, target) {
 }
 
 module.exports.calc = function (attackers, defender, replyData) {
+    warnInfiltrateOnly(attackers, replyData)
+
     // Validate: units with no attack stat can only be used with explode modifiers
     for (const attacker of attackers) {
         if (attacker.canAttack === false && !attacker.exploding) {
@@ -373,6 +388,8 @@ module.exports.calc = function (attackers, defender, replyData) {
 }
 
 module.exports.bulk = function (attacker, defender, replyData) {
+    warnInfiltrateOnly([attacker], replyData)
+
     const aforce =
         (attacker.iAtt() * attacker.iCurrentHp() * 100n) / attacker.iMaxHp()
     let dforce =
@@ -447,6 +464,8 @@ module.exports.bulk = function (attacker, defender, replyData) {
 }
 
 module.exports.provideDefHP = function (attacker, defender, replyData) {
+    warnInfiltrateOnly([attacker], replyData)
+
     let aforce =
         (attacker.iAtt() * attacker.iCurrentHp() * 100n) / attacker.iMaxHp()
     const dforce =
@@ -513,6 +532,8 @@ module.exports.provideDefHP = function (attacker, defender, replyData) {
 }
 
 module.exports.provideAttHP = function (attacker, defender, replyData) {
+    warnInfiltrateOnly([attacker], replyData)
+
     const aforce =
         (attacker.iAtt() * attacker.iCurrentHp() * 100n) / attacker.iMaxHp()
     let dforce =

--- a/bot/util/unitsList.js
+++ b/bot/util/unitsList.js
@@ -971,7 +971,9 @@ module.exports = {
         maxhp: 5,
         vet: false,
         vetNow: false,
-        att: 0,
+        // Cloaks can't attack units; their 2 attack only applies when infiltrating a city
+        att: 2,
+        infiltrateOnly: true,
         def: 0.5,
         bonus: 1,
         fort: false,


### PR DESCRIPTION
## Problem

Cloaks have `att: 0`, and `.c`/`.o` silently filter out attackers with 0 attack — so a Cloak in an attack sequence just vanished with no feedback. `.b`/`.e` threw a joke error. But in-game a Cloak *does* attack with 2 attack when infiltrating a city, and users trying to calculate that were being ignored.

## Change

- Cloak now has `att: 2` (its in-game infiltration attack) plus a new `infiltrateOnly` flag in `unitsList.js` / `unit.js`.
- All five fightEngine entry points (`calc`, `optim`, `bulk`, `provideDefHP`, `provideAttHP`) print a warning when an `infiltrateOnly` unit attacks: *“The only way a Cloak attacks is by infiltrating a city, so this result only applies to a city infiltration.”*

## Why defender-side outcomes don't change

- Retaliation is skipped when `defender.retaliation === false`, which the Cloak has.
- Retaliation damage uses the defender's **defense** force (`defenderCalc`), not its attack, so the att 0→2 change can't leak into any existing matchup.
- No simpleCalc snapshot suite covers the Cloak (no `cl.test.js`, not in the defenders list) — full suite passes unchanged (1,656,032 tests).

## Tests

- `.c cl, wa`: Cloak deals 5, dies to retaliation, warning printed.
- `.c wa, cl`: no warning when the Cloak is the defender.
- `.o cl, wa, de`: warning printed on the optimizer path.
- `.b cl, wa`: now computes (2 hits) instead of throwing, with warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)